### PR TITLE
fix: don't misdetect empty /sys/class/accel as TPU

### DIFF
--- a/setup
+++ b/setup
@@ -71,7 +71,7 @@ pip install -e . -q
 ACCELERATOR="cpu"
 if command -v nvidia-smi &>/dev/null && nvidia-smi &>/dev/null; then
     ACCELERATOR="gpu"
-elif ls /dev/accel* &>/dev/null 2>&1 || [ -n "$TPU_NAME" ] || [ -d /sys/class/accel ]; then
+elif ls /dev/accel* &>/dev/null 2>&1 || [ -n "$TPU_NAME" ] || [ -n "$(ls -A /sys/class/accel 2>/dev/null)" ]; then
     ACCELERATOR="tpu"
 fi
 


### PR DESCRIPTION
## What
`setup` misclassifies a machine as TPU when `/sys/class/accel` exists but is **empty**.

## Why
The accelerator probe uses:
```sh
elif ls /dev/accel* &>/dev/null 2>&1 || [ -n "$TPU_NAME" ] || [ -d /sys/class/accel ]; then
```
`[ -d /sys/class/accel ]` is true for an empty directory, so a host with an empty `/sys/class/accel` (as reported in #31) is detected as TPU and installs `jax[tpu]` instead of the CPU/GPU build.

## Fix
Require the directory to be **non-empty**:
```sh
[ -n "$(ls -A /sys/class/accel 2>/dev/null)" ]
```
A real TPU populates `/sys/class/accel` with device entries, so it is still detected; an empty (or missing) directory now correctly falls through to CPU/GPU. The other two conditions (`/dev/accel*`, `$TPU_NAME`) are unchanged.

## Testing
`bash -n setup` passes. Verified the new test:
- empty dir → not TPU (fixes the bug)
- missing dir → not TPU
- populated dir (real TPU) → TPU (unchanged)

Closes #31