### PR TITLE
fix: pin jax/jaxlib/flax lower bounds to avoid linear_util ImportError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ name = "needle"
 version = "0.1.0"
 requires-python = ">=3.11"
 dependencies = [
-    "jax",
-    "jaxlib",
-    "flax",
+    "jax>=0.4.30",
+    "jaxlib>=0.4.30",
+    "flax>=0.8.0",
     "optax",
     "datasets",
     "huggingface_hub",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-jax
-jaxlib
-flax
+jax>=0.4.30
+jaxlib>=0.4.30
+flax>=0.8.0
 optax
 datasets
 huggingface_hub


### PR DESCRIPTION
## What
Fixes the `ImportError: cannot import name 'linear_util'` reported in #24.

## Why
`pyproject.toml` and `requirements.txt` pin `jax`, `jaxlib` and `flax` with **no lower bounds**:
```
jax
jaxlib
flax
```
so a resolver can land on an old Flax (<0.8) that does `from jax import linear_util` while pulling a modern JAX. `jax.linear_util` was **removed in JAX 0.4.24**, so that combination raises `ImportError: cannot import name 'linear_util'` at import time — exactly what the reporter hit.

## Fix
Add lower bounds so a compatible set is always selected (in both files):
```
jax>=0.4.30
jaxlib>=0.4.30
flax>=0.8.0
```
Flax >= 0.8 no longer imports the removed symbol; JAX >= 0.4.30 is a safe, widely-available floor.

## Testing
Fresh venv, `pip install -e .`, then `python -c "import needle"`:
- resolves `jax 0.10.2 / jaxlib 0.10.2 / flax 0.12.7` (all satisfy the floors)
- `import needle` and `from needle.model.architecture import SimpleAttentionNetwork` succeed

Note: PR #29 proposes removing `requirements.txt`; if it merges first, the `pyproject.toml` floors still fully cover this fix.

Closes #24