### PR TITLE
fix: don't import `datasets` on the inference path

### DIFF
--- a/needle/__init__.py
+++ b/needle/__init__.py
@@ -11,7 +11,7 @@ from needle.model.run import (
     encode_for_retrieval,
     retrieve_tools,
 )
-from needle.dataset.dataset import get_tokenizer
+from needle.dataset.tokenizer import get_tokenizer
 
 __all__ = [
     "SimpleAttentionNetwork",

--- a/needle/dataset/__init__.py
+++ b/needle/dataset/__init__.py
@@ -1,2 +1,1 @@
 from .tokenizer import *  # noqa: F401,F403
-from .dataset import *  # noqa: F401,F403

--- a/needle/model/run.py
+++ b/needle/model/run.py
@@ -8,7 +8,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from ..dataset.dataset import get_tokenizer, to_snake_case, DEFAULT_MAX_ENC_LEN, DEFAULT_MAX_GEN_LEN
+from ..dataset.tokenizer import get_tokenizer, to_snake_case, DEFAULT_MAX_ENC_LEN, DEFAULT_MAX_GEN_LEN
 from .architecture import (
     SimpleAttentionNetwork,
     TransformerConfig,


### PR DESCRIPTION
`import needle` pulled in HuggingFace `datasets` (and its `pyarrow`/`pandas`/`fsspec` tree) even though nothing on the inference path uses it. The tokenizer symbols that `run.py` and `__init__.py` need are defined in `needle/dataset/tokenizer.py` but were being imported through `needle/dataset/dataset.py`, which imports `datasets` at module level.

This repoints those imports at the module where the symbols are actually defined. Same objects, no API or dependency changes.

Closes #40 

### Changes

| File | Change |
| -- | -- |
| needle/__init__.py:14 | dataset.dataset → dataset.tokenizer |
| needle/model/run.py:11 | dataset.dataset → dataset.tokenizer |
| needle/dataset/__init__.py:2 | removed from .dataset import * |

**The third change is required, not cleanup.** `needle/dataset/__init__.py` executes on *any* `needle.dataset.*` import, so it triggers `datasets` before `tokenizer.py` is ever reached. Without it, the first two changes have no effect.

### Verification

```bash
python -c "import sys; import needle; print('datasets' in sys.modules)"
# before: True
# after:  False
```

- `needle.get_tokenizer`, `needle.generate`, `needle.load_checkpoint` all still resolve
- `get_tokenizer` is the same object as before (`gt1 is gt2`)
- `from needle.dataset.dataset import ...` still works; `datasets` loads lazily when training code actually runs

### Safety

No internal consumer relies on the star re-export. All existing imports are either submodule imports (`from ..dataset import dataset as data_mod`, `from ..dataset import generate as gd`) or submodule-qualified (`from .dataset import ...`), none of which are affected by removing it.