### PR TITLE
Add Windows setup script and update README with Windows quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,35 @@ Please use the UI in the next section to test on your own tools, and finetune ac
 
 ## Quickstart
 
+### macOS / Linux
+
 ```bash
 git clone https://github.com/cactus-compute/needle.git
 cd needle && source ./setup
+needle playground
+```
+
+### Windows
+
+```bat
+git clone https://github.com/cactus-compute/needle.git
+cd needle
+.\setup.bat
+```
+
+> **Note:** `setup.bat` creates a `.venv`, installs all dependencies (including JAX in CPU mode), and prompts for an optional W&B API key.
+
+After setup completes, activate the virtual environment in every new terminal session before running needle commands:
+
+```powershell
+.\.venv\Scripts\Activate.ps1
+```
+
+> **Tip:** If PowerShell blocks the script, run `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser` once and retry.
+
+Then launch the playground:
+
+```powershell
 needle playground
 ```
 

--- a/setup.bat
+++ b/setup.bat
@@ -1,0 +1,60 @@
+@echo off
+set VENV_DIR=.venv
+
+:: Find Python 3.11+
+set PYTHON_CMD=
+py -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" >nul 2>&1
+if %errorlevel% == 0 (
+    set PYTHON_CMD=py
+) else (
+    python -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" >nul 2>&1
+    if %errorlevel% == 0 (
+        set PYTHON_CMD=python
+    )
+)
+
+if "%PYTHON_CMD%"=="" (
+    echo Error: Python ^>= 3.11 is required. Please install Python 3.11+ from https://www.python.org/
+    exit /b 1
+)
+
+:: Check if venv exists and is valid
+set RECREATE=0
+if not exist "%VENV_DIR%\Scripts\python.exe" (
+    set RECREATE=1
+) else (
+    "%VENV_DIR%\Scripts\python.exe" -c "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)" >nul 2>&1
+    if errorlevel 1 set RECREATE=1
+)
+
+if %RECREATE%==1 (
+    echo Creating virtual environment with %PYTHON_CMD%...
+    if exist "%VENV_DIR%" rmdir /s /q "%VENV_DIR%"
+    %PYTHON_CMD% -m venv "%VENV_DIR%"
+) else (
+    echo Virtual environment already exists.
+)
+
+call "%VENV_DIR%\Scripts\activate.bat"
+
+echo Installing dependencies...
+python -m pip install --upgrade pip
+python -m pip install -e .
+
+:: On native Windows, JAX GPU wheels do not exist.
+:: Only CPU mode is supported natively on Windows.
+echo Installing native Windows JAX (CPU mode)...
+python -m pip install -U jax jaxlib
+
+:: Sanity check
+python -c "import jax; print('JAX devices:', jax.devices())" || echo Warning: jax import failed; check the install above.
+
+:: Prompt for W&B key
+if "%WANDB_API_KEY%"=="" (
+    echo.
+    echo   Enter your W^&B API key ^(https://wandb.ai/authorize^)
+    echo   Press Enter to skip.
+    set /p WANDB_API_KEY="  > "
+)
+
+needle --help


### PR DESCRIPTION
## Summary

Adds Windows support to the Needle project.

### Changes

**`setup.bat`** (new file)
- Creates a `.venv` virtual environment using Python 3.11+
- Installs all dependencies via `pip install -e .`
- Installs JAX in CPU mode (only mode supported natively on Windows)
- Optionally prompts for a W&B API key
- Runs `needle --help` as a sanity check

**`README.md`**
- Split Quickstart into **macOS / Linux** and **Windows** sub-sections
- Added step-by-step Windows instructions: run `setup.bat`, activate `.venv\Scripts\Activate.ps1`, then `needle playground`
- Added tip about setting PowerShell execution policy if the activation script is blocked

### Testing
Verified end-to-end on Windows 11 with Python 3.11 — `needle playground` successfully launched the Gradio UI at http://127.0.0.1:7860.
