### PR TITLE
fix: allow configuring OpenRouter endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ needle generate-data --tools my_tools.json --num-samples 500 --output data.jsonl
 needle generate-data --augment data.jsonl --num-samples 500      # expand an existing JSONL
 ```
 
+Set `OPENROUTER_URL` to use an OpenAI-compatible gateway instead of the default OpenRouter endpoint.
+
 **2. LoRA fine-tune.** The base checkpoint auto-downloads from Hugging Face if you do not pass `--checkpoint`. `--generate N` first synthesizes N more examples from the tools in your data (also needs `OPENROUTER_API_KEY`).
 
 ```sh

--- a/needle/model/finetune.py
+++ b/needle/model/finetune.py
@@ -16,7 +16,9 @@ from .tokenizer import (
 LORA_TARGETS = ("q_proj", "k_proj", "v_proj", "gate_proj", "out_proj")
 DEFAULT_BASE = "checkpoints/needle2.pkl"
 
-OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+OPENROUTER_URL = os.environ.get(
+    "OPENROUTER_URL", "https://openrouter.ai/api/v1/chat/completions"
+)
 DEFAULT_MODEL = "deepseek/deepseek-v4-flash"
 
 _GEN_SYSTEM = (

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,4 +1,5 @@
 import json
+import importlib
 
 import pytest
 
@@ -41,6 +42,18 @@ def test_generate_examples_requires_api_key(monkeypatch):
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
     with pytest.raises(RuntimeError):
         finetune.generate_examples([{"name": "f"}], n=1)
+
+
+def test_openrouter_url_can_be_overridden_from_environment(monkeypatch):
+    monkeypatch.setenv("OPENROUTER_URL", "https://gateway.example.test/v1/chat")
+    from needle.model import finetune
+    importlib.reload(finetune)
+
+    try:
+        assert finetune.OPENROUTER_URL == "https://gateway.example.test/v1/chat"
+    finally:
+        monkeypatch.delenv("OPENROUTER_URL", raising=False)
+        importlib.reload(finetune)
 
 
 def _unique_generator():


### PR DESCRIPTION
## Summary
- read the OpenRouter chat-completions endpoint from `OPENROUTER_URL`
- retain the existing OpenRouter endpoint as the default
- document the override and cover it with a regression test

Fixes #50.

## Validation
- `python -m pytest tests/test_generate.py`