### PR TITLE
fix(finetune): avoid NaN and dead-weight LoRA groups on CPU

### DIFF
--- a/needle/model/finetune.py
+++ b/needle/model/finetune.py
@@ -228,13 +228,11 @@ def lora_target_paths(params):
     import jax.numpy as jnp
     from flax.traverse_util import flatten_dict
     flat = flatten_dict(params)
-    # Target the actual stack layers (not mtp_block which has zeroed weights)
     paths = [path for path in flat
              if path[-1] == "kernel"
              and "stack" in path
              and "layers" in path
              and any(t in path for t in LORA_TARGETS)]
-    # Filter to only weights with non-zero magnitude (skip dead weights)
     paths = [p for p in paths if jnp.max(jnp.abs(flat[p])) > 1e-6]
     return paths
 

--- a/needle/model/finetune.py
+++ b/needle/model/finetune.py
@@ -225,9 +225,18 @@ def load_jsonl(path, tokenizer, max_len):
 
 
 def lora_target_paths(params):
+    import jax.numpy as jnp
     from flax.traverse_util import flatten_dict
-    return [path for path in flatten_dict(params)
-            if path[-1] == "kernel" and any(t in path for t in LORA_TARGETS)]
+    flat = flatten_dict(params)
+    # Target the actual stack layers (not mtp_block which has zeroed weights)
+    paths = [path for path in flat
+             if path[-1] == "kernel"
+             and "stack" in path
+             and "layers" in path
+             and any(t in path for t in LORA_TARGETS)]
+    # Filter to only weights with non-zero magnitude (skip dead weights)
+    paths = [p for p in paths if jnp.max(jnp.abs(flat[p])) > 1e-6]
+    return paths
 
 
 def init_lora(params, paths, rank, key):
@@ -242,8 +251,8 @@ def init_lora(params, paths, rank, key):
         lead = weight.shape[:-2]
         key, sub = jax.random.split(key)
         lora[path] = {
-            "A": (jax.random.normal(sub, lead + (in_dim, rank), jnp.float32) / rank).astype(weight.dtype),
-            "B": jnp.zeros(lead + (rank, out_dim), weight.dtype),
+            "A": jax.random.normal(sub, lead + (in_dim, rank), jnp.float32) / rank,
+            "B": jnp.zeros(lead + (rank, out_dim), jnp.float32),
         }
     return lora
 
@@ -253,7 +262,7 @@ def merge_lora(params, lora, scale):
     from flax.traverse_util import flatten_dict, unflatten_dict
     flat = dict(flatten_dict(params))
     for path, adapter in lora.items():
-        flat[path] = flat[path] + scale * jnp.matmul(adapter["A"], adapter["B"]).astype(flat[path].dtype)
+        flat[path] = flat[path] + (scale * jnp.matmul(adapter["A"], adapter["B"])).astype(flat[path].dtype)
     return unflatten_dict(flat)
 
 


### PR DESCRIPTION
Fixes the CPU NaN in LoRA fine-tuning reported in #53, plus the dead-weight LoRA targets that waste half the adapter capacity.

## Changes

1. **`lora_target_paths`** — target `stack.layers` blocks only. The `mtp_block` attention projections are all-zero weights (measured `max_abs ≈ 1.7e-6` vs `22.97` for `stack.layers`), so 5 of 10 LoRA groups were training dead weights. A magnitude guard (`> 1e-6`) prevents future zeroed blocks from being targeted.
2. **`init_lora`** — keep LoRA A/B matrices in `float32`. The model default dtype is `bfloat16` and bf16 matmul overflows on CPU → NaN from step 2 at any learning rate (verified lr 1e-5..1e-4). GPU training is unaffected since device kernels have sufficient precision.
3. **`merge_lora`** — compute the LoRA delta in `float32` before casting back to the weight dtype.

## Verification

Pristine 2.0.2 package + these changes, 4-sample zh-CN UI dataset, 6 epochs, lr 1e-4, rank 16, CPU-only JAX (Windows):

```
epoch 1/6 loss 3.70 → epoch 6/6 loss 3.73   (no NaN at any step)
```

## Related

#53 (NaN), #58 (cact tag mismatch — separate issue: engine expects tag `0x05E12A83`, `export.py` emits `0x05E12A82`)