### PR TITLE
fix: align package license metadata with MIT license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.0.0"
 description = "A 14MB foundation tool-calling model for tiny devices: inference, LoRA finetuning, and build."
 requires-python = ">=3.9"
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = { text = "MIT" }
 dependencies = [
     "huggingface_hub",
     "numpy",


### PR DESCRIPTION
## Summary
- align the package license declaration with the repository's MIT `LICENSE`
- remove conflicting Apache-2.0 metadata from published artifacts

## Why
Built wheels currently declare `License: Apache-2.0` while bundling the repository's MIT license file. This keeps package-index and license-scanner metadata consistent with the license distributed in the package.

## Testing
- `pytest -q -m "not slow"` (28 passed, 5 skipped, 5 deselected)
- `python -m build`
- `python -m twine check` (sdist and wheel passed)
- checked the wheel `METADATA` reports `License: MIT` and `License-File: LICENSE`