### PR TITLE
fix: retain cact weights buffer for native engine

### DIFF
--- a/needle/__init__.py
+++ b/needle/__init__.py
@@ -50,6 +50,7 @@ class Needle:
     def __init__(self, tools=None, system=None, weights=None, tool_index_path=None, buffer_size=65536):
         self._functions = {}
         self._weights = weights
+        self._weight_blob = None
         if weights:
             warnings.warn("finetuning does not update the confidence head, so scores are "
                           "uncalibrated for tuned weights; this agent reports confidence as None",
@@ -66,9 +67,12 @@ class Needle:
         if _active is self:
             return
         if self._weights and _active_weights != self._weights:
-            with open(self._weights, "rb") as handle:
-                blob = handle.read()
-            if _lib().needle_load(blob, len(blob)) != 0:
+            if self._weight_blob is None:
+                with open(self._weights, "rb") as handle:
+                    # needle_load does not copy the input buffer and retains/dereferences
+                    # it during inference, so the bytes object must be kept alive on self.
+                    self._weight_blob = handle.read()
+            if _lib().needle_load(self._weight_blob, len(self._weight_blob)) != 0:
                 raise RuntimeError(
                     f"failed to load weights from {self._weights} - the .cact "
                     f"format is tied to the engine version, so an archive "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def _engine_available():
         here = os.path.dirname(needle.__file__)
         name = fetch._lib_name()
         cache = os.path.join(os.path.expanduser("~"), ".cache",
-                             "cactus-needle", needle.__version__, name)
+                             "cactus-needle", fetch.ENGINE_VERSION, name)
         return os.path.exists(os.path.join(here, name)) or os.path.exists(cache)
     except Exception:
         return False
@@ -39,6 +39,29 @@ def tiny_checkpoint(tmp_path_factory):
     params = jax.tree_util.tree_map(lambda x: np.asarray(x), params)
 
     path = tmp_path_factory.mktemp("ckpt") / "tiny.pkl"
+    with open(path, "wb") as handle:
+        pickle.dump({"format_version": 2, "params": params,
+                     "config": dict(vars(config))}, handle)
+    return str(path)
+
+
+@pytest.fixture(scope="session")
+def engine_checkpoint(tmp_path_factory):
+    import numpy as np
+    import jax
+    import jax.numpy as jnp
+    from needle.model.architecture import SimpleAttentionNetwork, TransformerConfig
+
+    config = TransformerConfig(
+        vocab_size=8192, d_model=512, num_heads=8, num_kv_heads=4, num_layers=4,
+        max_seq_len=2048, engram_layers=(1, 2), engram_slots=8192, mhc_lanes=4,
+        flash=False,
+    )
+    model = SimpleAttentionNetwork(config)
+    params = model.init(jax.random.PRNGKey(0), jnp.ones((1, 8), jnp.int32))["params"]
+    params = jax.tree_util.tree_map(lambda x: np.asarray(x), params)
+
+    path = tmp_path_factory.mktemp("ckpt") / "engine_ckpt.pkl"
     with open(path, "wb") as handle:
         pickle.dump({"format_version": 2, "params": params,
                      "config": dict(vars(config))}, handle)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,7 +1,11 @@
 import os
+import subprocess
+import sys
 import types
 
 import pytest
+
+from conftest import requires_engine
 
 pytestmark = pytest.mark.slow
 
@@ -57,3 +61,47 @@ def test_export_round_trips_a_projection(tiny_checkpoint, tmp_path):
     dequant = tensors[2]
     assert dequant.shape == original.shape
     assert np.corrcoef(dequant.ravel(), original.ravel())[0, 1] > 0.9
+
+
+@requires_engine
+@pytest.mark.parametrize("bits", ["2", "4"])
+def test_native_engine_loads_and_runs_built_cact(engine_checkpoint, tmp_path, bits):
+    from needle.model.finetune import build_main
+
+    out = str(tmp_path / f"engine_w{bits}.cact")
+    build_main(_build_args(engine_checkpoint, out, bits=bits))
+
+    code = (
+        "import needle\n"
+        "@needle.tool\n"
+        "def dummy_tool(query: str):\n"
+        "    return 'ok'\n"
+        f"agent = needle.Needle(weights={out!r}, tools=[dummy_tool])\n"
+        "response = agent.complete('test query')\n"
+        "assert isinstance(response, dict) and 'type' in response\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, f"Native engine subprocess failed (exit code {proc.returncode}):\nSTDOUT: {proc.stdout}\nSTDERR: {proc.stderr}"
+
+
+@requires_engine
+def test_malformed_cact_raises_clean_exception(tmp_path):
+    bad_path = str(tmp_path / "bad.cact")
+    with open(bad_path, "wb") as f:
+        f.write(b"NOT_A_VALID_CACT_FILE_HEADER_BYTES_1234567890")
+
+    code = (
+        "import needle\n"
+        "@needle.tool\n"
+        "def dummy_tool(query: str):\n"
+        "    return 'ok'\n"
+        "try:\n"
+        f"    needle.Needle(weights={bad_path!r}, tools=[dummy_tool])\n"
+        "    exit(1)\n"
+        "except RuntimeError as e:\n"
+        "    if 'failed to load weights' in str(e):\n"
+        "        exit(0)\n"
+        "    exit(2)\n"
+    )
+    proc = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert proc.returncode == 0, f"Malformed load subprocess failed (exit code {proc.returncode}):\nSTDOUT: {proc.stdout}\nSTDERR: {proc.stderr}"


### PR DESCRIPTION
## Summary

Fixes #64.

When external `.cact` weights were loaded, `needle_load()` retained a pointer to the supplied buffer for subsequent inference. The Python wrapper previously passed a temporary `bytes` object whose lifetime ended after `_bind()` returned.

This could leave the native engine referencing invalid memory and cause a segmentation fault during `needle_complete()`.

This change retains the `.cact` buffer on the `Needle` instance for the lifetime of the agent.

## Root Cause

`needle_load()` retains the input buffer instead of copying it.

Previously, `_bind()` stored the `.cact` contents in a local variable:

```python
with open(self._weights, "rb") as handle:
    blob = handle.read()

_lib().needle_load(blob, len(blob))
```

The buffer was not retained by the Python object after `_bind()` returned.

The fix stores the buffer on the `Needle` instance:

`self._weight_blob = handle.read()`

so the underlying memory remains valid while the native engine may access it.

## Tests
Reproduced the original SIGSEGV before the fix.
Verified the regression test fails on the pre-fix version.
Verified the regression test passes after the fix.
Verified official `needle2.cact` loads successfully.
Verified locally generated `.cact` loads successfully.
Verified multiple agents with different weights can be switched safely.
Added subprocess isolation for native engine tests.
Added malformed `.cact` regression coverage.

## Test results
`pytest -v -m "not slow"` — 33 passed
`pytest -v tests/test_build.py` — 6 passed

Fixes [#64](https://github.com/cactus-compute/needle/issues/64?utm_source=chatgpt.com)