### PR TITLE
fix: correct license metadata in pyproject.toml (Apache-2.0 -> MIT)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "2.0.0"
 description = "A 14MB foundation tool-calling model for tiny devices: inference, LoRA finetuning, and build."
 requires-python = ">=3.9"
 readme = "README.md"
-license = { text = "Apache-2.0" }
+license = { text = "MIT" }
 dependencies = [
     "huggingface_hub",
     "numpy",


### PR DESCRIPTION
## Problem

The packaging metadata disagrees with the actual license:

- `LICENSE` file: **MIT** (Copyright (c) 2026 Cactus Compute) — GitHub also detects the repo as MIT.
- `pyproject.toml`: `license = { text = "Apache-2.0" }`

The daily release train publishes this metadata to PyPI, so the current release (2.0.4) reports the wrong license:

```
$ curl -s https://pypi.org/pypi/cactus-needle/json | jq -r .info.license
Apache-2.0
```

This creates conflicting license signals for downstream users: `pip`, `pip-licenses`, SBOM generators, and license-compliance scanners read Apache-2.0 from the package metadata while the actual grant in the repo is MIT.

## Change

One line in `pyproject.toml`:

```diff
-license = { text = "Apache-2.0" }
+license = { text = "MIT" }
```

## Verification

- `LICENSE` is the standard MIT text; `gh repo view --json licenseInfo` reports MIT.
- PyPI metadata for 2.0.4 shows `license: Apache-2.0` (the bug in production).
- No other file in the repo claims Apache-2.0 (`grep -ri apache --include='*.toml' --include='*.md' .` finds only this line).