### PR TITLE
docs: correct --bits default description in README build section

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ pip install "cactus-needle[metal]"
 needle build checkpoints/needle2.pkl --lora checkpoints/needle_lora.pkl --out my_needle.cact
 ```
 
-Add `--bits 2` (default 4) for a smaller model, or set `NEEDLE_HF_REPO=<you>/<model>` and pass `--upload` to publish the `.cact`. The counterpart `needle download <you>/<model>/my_needle.cact` pulls a published archive on any machine.
+Add `--bits 2` for a smaller model (by default the export follows the checkpoint's declared per-layer bit map, falling back to 4 when the checkpoint declares none), or set `NEEDLE_HF_REPO=<you>/<model>` and pass `--upload` to publish the `.cact`. The counterpart `needle download <you>/<model>/my_needle.cact` pulls a published archive on any machine.
 
 **4. Run it.** The engine is weights-agnostic, so a tuned `.cact` runs on it directly - no recompilation:
 


### PR DESCRIPTION
## Problem

README says:

> Add `--bits 2` **(default 4)** for a smaller model

But the CLI does not default to a flat 4 bits. `needle/model/finetune.py` `build_main()`:

```python
bits = args.bits                       # None unless --bits is passed
bits_map = None if bits else (getattr(config, "weight_bits", "") or None)
if not bits and not bits_map:
    bits = "4"                          # flat 4 only when the checkpoint declares no map
scheme = f"mixed[{bits_map}]" if bits_map else f"W{bits}"
```

So the default export follows the checkpoint's declared per-layer (`weight_bits`) map — a mixed scheme — and only falls back to flat 4-bit when the checkpoint declares none. The shipped base model is described as CQ 2-bit in the same README, so "default 4" misdescribes what a default `needle build` of the base checkpoint produces.

## Change

Reword the parenthetical to describe the real default. No code change.

## Verification

- Code path quoted above from `build_main()` (`needle/model/finetune.py`, ~line 420).
- `cli.py` registers `--bits` with `default=None, choices=["2", "4"]`.