### PR TITLE
docs: complete the llms.txt CLI summary (add fetch and download)

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -189,6 +189,8 @@ Preset demos, editable tools/prompt, multi-turn follow-ups, and a "Finetune on t
 - `needle run --checkpoint <base.pkl> --query "..." --tools tools.json` - JAX reference inference from a checkpoint (dev path; normal inference is the Python `Needle` API above).
 - `needle generate-data` / `needle finetune` / `needle build` - the fine-tuning pipeline.
 - `needle playground` - browser UI.
+- `needle fetch [--platform-tag <tag>] [--out <dir>]` - pre-download the inference engine for this machine (or another platform) into the cache; prints the path. For air-gapped devices, also see `NEEDLE_LIB_PATH` and `HF_HUB_OFFLINE` in doc/apis.md.
+- `needle download <org>/<repo>[/<file>.cact] [--out <dir>]` - pull a published `.cact` (single-archive repos need only `<org>/<repo>`).
 
 ## Common mistakes to avoid
 


### PR DESCRIPTION
## Problem

`llms.txt` opens with:

> This file is written for AI coding assistants. It is enough to write correct Needle code without reading the source.

But its **CLI summary** lists only `run`, `generate-data`/`finetune`/`build`, and `playground`. Two user-facing commands are missing:

- `needle fetch` — pre-download the engine (documented in `doc/apis.md` under Offline devices, incl. `--platform-tag` for cross-platform staging)
- `needle download` — pull a published `.cact` (documented in the README fine-tuning section)

Both exist in `needle/cli.py` (fetch: `--platform-tag`, `--out`; download: positional `spec` accepting `<org>/<repo>/<file>.cact` or bare `<org>/<repo>` when the repo holds a single archive — see `_weights_spec()` and the download handler). An assistant staging Needle on an air-gapped device from `llms.txt` alone would miss the offline workflow entirely (`NEEDLE_LIB_PATH`, `HF_HUB_OFFLINE`).

## Change

Add both commands to the CLI summary, one line each, matching the flags the CLI actually accepts, with a pointer to `doc/apis.md` for the full offline procedure.

## Verification

- `grep -n 'platform-tag' needle/cli.py` → the fetch parser accepts `--platform-tag` and `--out`.
- `grep -n '_weights_spec' needle/cli.py` → the download handler accepts `<org>/<repo>/<file>.cact` and bare `<org>/<repo>`.
- `doc/apis.md` Offline devices section documents `NEEDLE_LIB_PATH` and `HF_HUB_OFFLINE=1`.