### PR TITLE
stop base agents from silently answering on tuned weights

### DIFF
--- a/needle/__init__.py
+++ b/needle/__init__.py
@@ -69,6 +69,12 @@ class Needle:
         global _active, _active_weights, _active_blob
         if _active is self:
             return
+        if not self._weights and _active_weights:
+            raise RuntimeError(
+                f"{_active_weights} is loaded and the engine cannot unload it, "
+                f"so this agent would silently answer with those weights; "
+                f"construct agents that want the base model before any tuned "
+                f"one, or run them in separate processes")
         if self._weights and _active_weights != self._weights:
             with open(self._weights, "rb") as handle:
                 blob = handle.read()
@@ -139,7 +145,8 @@ class Needle:
         return response
 
     def extract(self, text, schema, max_new_tokens=256):
-        return extract(text, schema, max_new_tokens=max_new_tokens)
+        return extract(text, schema, max_new_tokens=max_new_tokens,
+                       weights=self._weights)
 
     def reset(self):
         self._bind()
@@ -154,11 +161,12 @@ def _jsonable(value):
     return str(value)
 
 
-def extract(text, schema, system=None, max_new_tokens=256):
+def extract(text, schema, system=None, max_new_tokens=256, weights=None):
     """One-shot structured extraction: declare `schema` as the only tool and return
     the parsed object (a Pydantic instance if `schema` is a model, else a dict).
-    Re-initializes the shared engine with this single schema."""
-    agent = Needle(tools=[schema], system=system)
+    Re-initializes the shared engine with this single schema. Defaults to whatever
+    weights are already loaded, since the engine cannot unload them."""
+    agent = Needle(tools=[schema], system=system, weights=weights or _active_weights)
     response = agent.complete(text, max_new_tokens)
     calls = response.get("function_calls") or []
     if not calls:

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -1,0 +1,96 @@
+import json
+import warnings
+
+import pytest
+
+ENVELOPE = json.dumps({"type": "call", "confidence": 0.9,
+                       "function_calls": [{"name": "City",
+                                           "arguments": {"city": "Paris"}}]}).encode("utf-8")
+
+
+class _Stub:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def needle_init(self, system, tools, index):
+        self.calls.append("init")
+        return 0
+
+    def needle_load(self, blob, size):
+        self.calls.append("load")
+        return 0
+
+    def needle_complete(self, text, max_new_tokens, buffer, size):
+        self.calls.append("complete")
+        buffer.value = ENVELOPE
+        return 0
+
+    def needle_reset(self):
+        self.calls.append("reset")
+
+
+@pytest.fixture
+def engine(monkeypatch):
+    import needle
+
+    calls = []
+    stub = _Stub(calls)
+    monkeypatch.setattr(needle, "_lib", lambda: stub)
+    monkeypatch.setattr(needle, "_active", None)
+    monkeypatch.setattr(needle, "_active_weights", None)
+    monkeypatch.setattr(needle, "_active_blob", None)
+    return calls
+
+
+@pytest.fixture
+def tuned(tmp_path):
+    path = tmp_path / "tuned.cact"
+    path.write_bytes(b"tuned weights")
+    return str(path)
+
+
+def _tuned_agent(path):
+    import needle
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        return needle.Needle(tools="[]", weights=path)
+
+
+def test_new_base_agent_refuses_once_tuned_weights_are_loaded(engine, tuned):
+    import needle
+
+    _tuned_agent(tuned)
+    with pytest.raises(RuntimeError, match="cannot unload"):
+        needle.Needle(tools="[]")
+
+
+def test_existing_base_agent_refuses_instead_of_answering_on_tuned_weights(engine, tuned):
+    import needle
+
+    base = needle.Needle(tools="[]")
+    base.complete("hello")
+    _tuned_agent(tuned)
+    with pytest.raises(RuntimeError, match="cannot unload"):
+        base.complete("hello")
+
+
+def test_tuned_agent_rebinds_without_reloading_its_own_weights(engine, tuned):
+    agent = _tuned_agent(tuned)
+    other = _tuned_agent(tuned)
+    other.complete("hello")
+    agent.complete("hello")
+    assert engine.count("load") == 1
+
+
+def test_extract_inherits_the_loaded_weights(engine, tuned):
+    import needle
+
+    _tuned_agent(tuned)
+    schema = {"name": "City", "parameters": {"type": "object",
+                                             "properties": {"city": {"type": "string"}}}}
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert needle.extract("the weather in Paris", schema) == {"city": "Paris"}
+    assert needle._active_weights == tuned
+    assert engine.count("load") == 1


### PR DESCRIPTION
needle_load swaps out the built in weights and there is no way to unload them, so once a tuned .cact is loaded it stays for the rest of the process. _bind only reloads when the agent has its own weights, so an agent made without weights just runs on whatever tuned weights are sitting there. it also reports a confidence score, which the package normally hides for tuned agents because the head is not tuned.

repro on engine 2.0.2, one process, same tools and same four queries every time

```
base agent on its own              0.813, 0.0048, 0.0463, 0.0522
tuned agent with the mask taken off  1.0, 0.4053, 1.0, 1.0
base agent made after the tuned one  1.0, 0.4053, 1.0, 1.0
```

the base agent matches the tuned one exactly. two base agents in one process give the same numbers as a base agent alone, so it is the weights and not leftover conversation state. an agent that already exists gets hit too, it answers fine until a tuned agent shows up and then changes. reset does not help, and loading a .cact built from the untuned checkpoint does not bring the built in weights back either.

fix is to raise instead of answering, since there is nothing to go back to. extract was building a weightless agent inside itself so it hit the same path, it now picks up whatever weights are loaded which also brings back the confidence masking. Needle.extract passes its own weights through now.

limitation, base and tuned agents still cannot live in the same process. that was already true, this just makes it visible.

tests/test_weights.py covers the four cases with a stub engine so it needs no engine and no .cact
