### PR TITLE
fix import on python 3.9

### DIFF
--- a/needle/__init__.py
+++ b/needle/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ctypes
 import json
 import os


### PR DESCRIPTION
`import needle` fails on python 3.9, which `pyproject.toml` claims to support with `requires-python = ">=3.9"`:

```
$ python3.9 -c "import needle"
  File ".../needle/__init__.py", line 147, in Needle
    def extract(self, text: str, schema: type | dict, max_new_tokens: int = 256) -> object:
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

cause: the type hints added in c94d256 (#74) use PEP 604 unions (`type | dict`, `str | None`) in three signatures in `needle/__init__.py`. annotations are evaluated at def time, and `types.UnionType` only exists from 3.10, so the module raises on import. pip installs fine on 3.9 and then nothing works.

`from __future__ import annotations` stores annotations as strings instead of evaluating them, so 3.9 never builds the union. no runtime behaviour changes and the hints still resolve for type checkers.

verified: on 3.9.25 `import needle` goes from the traceback above to importing cleanly, 3.12 is unaffected, and the test suite is identical before and after.

the alternative is bumping `requires-python` to `>=3.10`, which is your call. `release.yaml` only runs 3.12, so nothing currently catches this either way; happy to add a 3.9 import job in a follow-up if you want one.
