### PR TITLE
fix: emit tool description before parameters in build_schema

### DIFF
--- a/needle/agent/tools.py
+++ b/needle/agent/tools.py
@@ -135,9 +135,10 @@ def build_schema(fn: Callable) -> dict:
     parameters = {"type": "object", "properties": properties}
     if required:
         parameters["required"] = required
-    out = {"name": fn.__name__, "parameters": parameters}
+    out = {"name": fn.__name__}
     if description:
         out["description"] = description
+    out["parameters"] = parameters
     return out
 
 


### PR DESCRIPTION
build_schema appends the tool description after the parameters object. The model reads the tool JSON in its prompt in that order, and on zero-parameter tools it misreads the trailing description as a parameter spec, hallucinating it as an argument: a zero-arg tool with a docstring gets called as `accept_invitation(description="...")`, the call fails at invocation, and the turn dies at near-zero confidence. Any trailing key reproduces this, not just description.

Emitting `name, description, parameters` removes the misleading rendering. Verified against the shipped engine: the repro above goes from a hallucinated-argument failure to a clean call, and a check-then-act sequence over a zero-arg tool completes end to end. `tests/test_tools.py` passes. Engine-side hardening for the same class of failure: cactus-compute/needle-prod#15.