### PR TITLE
docs: document the weights parameter of needle.extract()

### DIFF
--- a/doc/apis.md
+++ b/doc/apis.md
@@ -8,7 +8,7 @@
 | `agent.reset()` | Rewind the conversation, keep the tools loaded. |
 | `needle.tool` | Decorator that turns a function into a tool schema (attached as `fn._needle_tool`). |
 | `needle.Field(...)` | Per argument constraints, attached inline with `typing.Annotated` or passed as a default. |
-| `needle.extract(text, schema, system=None, max_new_tokens=256)` | One shot extraction. Returns a Pydantic instance if `schema` is a model, else a dict, or `None` if nothing matched. |
+| `needle.extract(text, schema, system=None, max_new_tokens=256, weights=None)` | One shot extraction. Returns a Pydantic instance if `schema` is a model, else a dict, or `None` if nothing matched. `weights` selects a tuned `.cact` and defaults to whatever the engine already has loaded. |
 
 ## Declaring tools
 

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,7 @@ pip install cactus-needle
 - `agent.reset()` - rewind the conversation, keep the tools loaded.
 - `needle.tool` - decorator that turns a function into a tool schema (attached as `fn._needle_tool`).
 - `needle.Field(default=..., *, description, enum, const, ge, le, gt, lt, multiple_of, min_length, max_length, pattern, format, min_items, max_items, unique_items)` - per-argument constraints; attach inline with `typing.Annotated`.
-- `needle.extract(text, schema, system=None, max_new_tokens=256)` - one-shot extraction; returns a Pydantic instance if `schema` is a model, else a dict (or `None` if nothing matched).
+- `needle.extract(text, schema, system=None, max_new_tokens=256, weights=None)` - one-shot extraction; returns a Pydantic instance if `schema` is a model, else a dict (or `None` if nothing matched). `weights` selects a tuned `.cact` and defaults to whatever the engine already has loaded, so extraction inherits the active tuned model unless you pass another path.
 
 ## Defining tools (three equivalent ways)
 


### PR DESCRIPTION
## What

`needle.extract()` gained a `weights` parameter in f3dc9f9 ("feat: enhance Needle class to handle weights"), but both API references still document the old four-argument signature:

- `llms.txt` (Core API): `needle.extract(text, schema, system=None, max_new_tokens=256)`
- `doc/apis.md` (API table): same signature

This PR syncs both entries with the actual signature:

```python
def extract(text: str, schema: type | dict, system: str | None = None,
            max_new_tokens: int = 256, weights: str | None = None) -> object
```

and documents the default: `weights=None` falls back to `_active_weights`, i.e. extraction inherits whatever the engine already has loaded.

## Why it matters

`llms.txt` states it is "enough to write correct Needle code without reading the source" — a reader following the documented signature has no way to know extraction silently runs on the loaded tuned weights (codified in `tests/test_weights.py::test_extract_inherits_the_loaded_weights`), or that a different `.cact` can be selected per call.

## Verification

- Signature cross-checked against `needle/__init__.py` at f3dc9f9 (module-level `extract` and the `Needle.extract` method, which forwards `self._weights`).
- Default behavior cross-checked against `test_extract_inherits_the_loaded_weights` (one load, `_active_weights` unchanged).
- Docs-only change; no code touched.
