### PR TITLE
docs: note the engine cannot unload weights (base-model agents first or separate processes)

### DIFF
--- a/doc/apis.md
+++ b/doc/apis.md
@@ -105,6 +105,7 @@ Needle solves every problem as a function call. The context declares what may be
 - `reasoning` is the model's short derivation of each argument from its source span (`'ten minutes' -> minutes 10`). It is generated unconstrained; only the call itself is grammar-constrained, so the JSON cannot be malformed while the derivation stays legible.
 - After you execute a call, pass the result back as the next `complete()`. The model continues from it, and later arguments may depend on earlier results: `search_for_contact` first, then `send_instant_message` with the returned `contact_id`. A final `"type": "respond"` with empty `function_calls` signals the loop is done; the answer is the tool results themselves, which `run()` collects on the final response as `results`. No free text is generated.
 - A session shares one toolset. Later turns are bare queries against the same tools; `reset()` rewinds the conversation and keeps the tools loaded.
+- Weights stay loaded for the process. Once a tuned `.cact` is bound, constructing or calling a base-model agent raises instead of silently answering with those weights; construct base-model agents before tuned ones, or run tuned and base workloads in separate processes. Rebinding agents on the same weights is fine.
 
 ## Extraction
 

--- a/llms.txt
+++ b/llms.txt
@@ -199,4 +199,5 @@ Preset demos, editable tools/prompt, multi-turn follow-ups, and a "Finetune on t
 - Do not create one `Needle` per turn for a conversation; reuse the instance so context carries. New tools = new instance.
 - `import needle` does not import JAX; only `needle finetune`/`build` do.
 - `weights=` expects a `.cact` (from `needle build`), not a `.pkl` checkpoint.
+- The engine cannot unload weights: once a tuned `.cact` is bound, constructing or calling a base-model agent raises instead of silently answering with those weights. Construct agents that want the base model before any tuned one, or run them in separate processes.
 ```


### PR DESCRIPTION
## What

f3dc9f9 added a guard in `Needle._bind()`: once tuned weights are loaded, the engine cannot unload them, so constructing a new base-model agent — or calling `complete()` on a base-model agent constructed earlier — raises `RuntimeError` instead of silently answering with the tuned weights:

```
RuntimeError: <path> is loaded and the engine cannot unload it, so this agent
would silently answer with those weights; construct agents that want the base
model before any tuned one, or run them in separate processes
```

This behavioral constraint is documented nowhere: not in `llms.txt` ("Common mistakes to avoid"), not in `doc/apis.md` ("Behaviour"). Both files are the reference a user is told to rely on, and the failure mode (mixed base/tuned workloads in one process) is a realistic one.

This PR adds one bullet to each file stating the constraint and the two supported patterns (base-model agents first, or separate processes).

## Evidence

Codified upstream in `tests/test_weights.py`:
- `test_new_base_agent_refuses_once_tuned_weights_are_loaded`
- `test_existing_base_agent_refuses_instead_of_answering_on_tuned_weights`
- `test_tuned_agent_rebinds_without_reloading_its_own_weights` (same weights rebind fine — only base-after-tuned raises)

## Verification

- Wording cross-checked against the `RuntimeError` message in `needle/__init__.py` and the three tests above.
- Docs-only change; no code touched.
