### PR TITLE
fix: needle run CLI crashes on undefined args and BUF_BUCKET NameError

### DIFF
--- a/needle/model/run.py
+++ b/needle/model/run.py
@@ -11,13 +11,7 @@ from .tokenizer import get_tokenizer, BOS_ID, EOS_ID, PAD_ID
 from .architecture import SimpleAttentionNetwork, TransformerConfig
 
 CHECKPOINT_FORMAT_VERSION = 2
-
-# Round decode buffers up to a multiple of this many tokens so JIT-compiled
-# decode functions get reused across calls with similar prompt lengths
-# instead of retracing for every distinct length (mirrors the bucketing in
-# finetune.fit_max_len).
 BUF_BUCKET = 128
-
 _decode_fn_cache = {}
 
 

--- a/needle/model/run.py
+++ b/needle/model/run.py
@@ -12,6 +12,12 @@ from .architecture import SimpleAttentionNetwork, TransformerConfig
 
 CHECKPOINT_FORMAT_VERSION = 2
 
+# Round decode buffers up to a multiple of this many tokens so JIT-compiled
+# decode functions get reused across calls with similar prompt lengths
+# instead of retracing for every distinct length (mirrors the bucketing in
+# finetune.fit_max_len).
+BUF_BUCKET = 128
+
 _decode_fn_cache = {}
 
 
@@ -216,11 +222,11 @@ def main(args):
     model = SimpleAttentionNetwork(config)
     tokenizer = get_tokenizer(config.vocab_size)
 
-    prompt = args.prompt or "The most surprising thing about"
+    prompt = args.query or "The most surprising thing about"
     print(f"prompt: {prompt!r}")
     generate(
         model, params, tokenizer, prompt,
-        max_new_tokens=args.max_new_tokens,
-        temperature=args.temperature,
+        max_new_tokens=args.max_len,
+        temperature=getattr(args, "temperature", 0.0),
         seed=args.seed,
     )


### PR DESCRIPTION
## Summary

`needle run` currently crashes immediately on invocation:

- `run.py:main()` reads `args.prompt`, `args.max_new_tokens`, and `args.temperature`, but the `run` subparser in `cli.py` only defines `--query`, `--tools`, `--max-len`, `--seed`, and `--no-constrained` — none of `prompt`/`max_new_tokens`/`temperature` exist on the parsed `Namespace`, so any invocation raises `AttributeError`.
- Separately, `batch_generate()` references `BUF_BUCKET` for buffer-length rounding, but that constant is never defined anywhere in the codebase, causing a `NameError` for any caller of `batch_generate`.

This fixes `main()` to use the CLI flags that actually exist (`args.query`, `args.max_len`, `args.seed`), falls back to `temperature=0.0` (greedy decoding, matching `generate()`'s own default) since there's no `--temperature` flag, and defines `BUF_BUCKET = 128`, matching the bucket size already used for the same purpose in `finetune.fit_max_len`.

Fixes #84

## Test plan

- [x] `python3 -m py_compile needle/model/run.py` passes
- [x] Verified `BUF_BUCKET` was not defined anywhere else in the repo before adding it
- [x] Verified `args.prompt`/`args.max_new_tokens`/`args.temperature` are not produced by any argparse subparser in `cli.py`
- [x] Would appreciate a maintainer/CI run against an actual checkpoint, since I don't have a `.pkl` checkpoint locally to exercise `needle run` end-to-end