### PR TITLE
fix: infer primitive types for IntEnum and numeric Literals in build_schema

### DIFF
--- a/needle/agent/tools.py
+++ b/needle/agent/tools.py
@@ -64,12 +64,16 @@ def _json_type(annotation):
         if annotation in _JSON_TYPES:
             return {"type": _JSON_TYPES[annotation]}
         if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
-            return {"type": "string", "enum": [e.value for e in annotation]}
+            values = [e.value for e in annotation]
+            val_type = _JSON_TYPES.get(type(values[0]), "string") if values else "string"
+            return {"type": val_type, "enum": values}
         if _is_pydantic_model(annotation):
             return pydantic_schema(annotation)["parameters"]
         return {"type": "string"}
     if origin is typing.Literal:
-        return {"type": "string", "enum": list(typing.get_args(annotation))}
+        args = list(typing.get_args(annotation))
+        val_type = _JSON_TYPES.get(type(args[0]), "string") if args else "string"
+        return {"type": val_type, "enum": args}
     if origin in (list, typing.List):
         args = typing.get_args(annotation)
         return {"type": "array", "items": _json_type(args[0]) if args else {"type": "string"}}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,3 +1,4 @@
+import enum
 import sys
 import typing
 
@@ -138,3 +139,22 @@ def test_tool_decorator_preserves_callable():
 
     assert greet("bob") == "hi bob"
     assert greet._needle_tool["name"] == "greet"
+
+
+def test_numeric_literal_and_int_enum_schema():
+    class Level(enum.IntEnum):
+        LOW = 1
+        MEDIUM = 2
+        HIGH = 3
+
+    def f(
+        port: typing.Literal[80, 443, 8080],
+        level: Level,
+        mode: typing.Literal["fast", "slow"] = "fast"
+    ):
+        pass
+
+    props = build_schema(f)["parameters"]["properties"]
+    assert props["port"] == {"type": "integer", "enum": [80, 443, 8080]}
+    assert props["level"] == {"type": "integer", "enum": [1, 2, 3]}
+    assert props["mode"] == {"type": "string", "enum": ["fast", "slow"]}


### PR DESCRIPTION
### Summary
Previously, `_json_type()` hardcoded `{"type": "string"}` for all `typing.Literal` and `enum.Enum` types regardless of the underlying values. This caused `IntEnum` and numeric `Literal` values (e.g. `Literal[80, 443]`) to emit incorrect string schema types, affecting downstream grammar-constrained decoding.

### Changes
- Dynamically infer primitive JSON schema types (`integer`, `number`, `boolean`, `string`) from the values of `enum.Enum` and `typing.Literal`.
- Added unit test `test_numeric_literal_and_int_enum_schema` in `tests/test_tools.py`.

### Testing
- `pytest tests/test_tools.py` passes all 12 tests.