### PR TITLE
docs: sync needle run --temperature and finetune --generate options

### DIFF
--- a/doc/finetuning.md
+++ b/doc/finetuning.md
@@ -41,6 +41,8 @@ To grow a small hand written set, seed the generator with it (needs `OPENROUTER_
 needle generate-data --augment data.jsonl --num-samples 1000
 ```
 
+`finetune` runs the same generator inline: `--generate 300` synthesizes that many extra examples before training starts (`0` disables it, the default), `--model` picks the OpenRouter model (default `deepseek/deepseek-v4-flash`), and `--workers` bounds concurrent requests (default 8).
+
 The playground button labelled Finetune on these tools runs the same pipeline from the browser.
 
 Training is plain JAX, so it runs on any accelerator jax supports. On an NVIDIA machine install the CUDA build and the same command trains on the GPU, nothing else changes:

--- a/llms.txt
+++ b/llms.txt
@@ -197,7 +197,7 @@ Adapt by swapping the Literal values for your own and keeping the shapes: closed
 
 ## CLI summary
 
-- `needle run --checkpoint <base.pkl> --query "..." --tools tools.json` - JAX reference inference from a checkpoint (dev path; normal inference is the Python `Needle` API above).
+- `needle run --checkpoint <base.pkl> --query "..." --tools tools.json [--temperature <t>]` - JAX reference inference from a checkpoint (dev path; normal inference is the Python `Needle` API above); `--temperature` defaults to 0 (greedy).
 - `needle generate-data` / `needle finetune` / `needle build` - the fine-tuning pipeline.
 - `needle playground` - browser UI.
 - `needle fetch [--platform-tag <tag>] [--out <dir>]` - pre-download the inference engine for this machine (or another platform) into the cache; prints the path. For air-gapped devices, also see `NEEDLE_LIB_PATH` and `HF_HUB_OFFLINE` in doc/apis.md.


### PR DESCRIPTION
## What

Two documentation sync gaps between the CLI (as of `4ac96b1` / #88 and `25ef4ac` / #93) and the docs:

1. **llms.txt CLI summary omits `needle run --temperature`.** The entry lists `--checkpoint`/`--query`/`--tools`, but #88 wired `--tools` *and* `--temperature` through `needle run`. Only `--temperature` is missing from the summary.

2. **doc/finetuning.md does not mention the inline generator options of `needle finetune`.** `--generate <n>` (synthesize N extra examples via OpenRouter before training), `--model <id>` (default `deepseek/deepseek-v4-flash`), and `--workers <n>` (default 8) are documented in README ("Key options" list) and llms.txt, but the finetuning deep dive — the doc that explains exactly this pipeline, including "when validation loss rises, add data" — never mentions the built-in synthesis path. It only covers the separate `generate-data` command.

## Evidence

- `needle/cli.py`, `run` subparser: `--temperature`, `type=float, default=0.0, help="Sampling temperature (0 = greedy)"`.
- `needle/model/run.py` `generate()`: `temperature <= 0.0` → `argmax` (greedy); above 0 → `jax.random.categorical(logits / temperature)`.
- `needle/cli.py`, `finetune` subparser: `--generate` (`default=0`, "Generate N extra examples via OpenRouter before training (0 = off)"), `--model` (`default="deepseek/deepseek-v4-flash"`), `--workers` (`default=8`).
- README already covers all three finetune options; doc/finetuning.md and llms.txt were the two files out of sync.

## Changes

- `llms.txt`: add `[--temperature <t>]` to the `needle run` entry with a short "defaults to 0 (greedy)" clause, matching the bracketed-optional-flag style of the neighbouring entries.
- `doc/finetuning.md`: one sentence after the `generate-data` block describing `--generate`/`--model`/`--workers`, using only facts verifiable from the CLI definitions.

Docs only; no code paths touched.
