### PR TITLE
Separate training dependencies from the runtime package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -e ".[test]"
+      - run: pip install -e ".[test,train]"
       - run: pytest -q -m "not slow"
 
   release:
@@ -49,11 +49,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write        # pushes the vX.Y.Z release tag
-      id-token: write        
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0  
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Each block carries its update rule. Here x̂ is the RMS-normalised flattening of
 pip install cactus-needle
 ```
 
+The runtime package does not install the training stack. Add the `train` extra
+when using fine-tuning or checkpoint export:
+
+```sh
+pip install "cactus-needle[train]"
+```
+
 Needle reads your tool descriptions to decide what to call and how to fill arguments, so describing them well is the whole game.
 
 **Simple**: decorate a function. The signature gives the argument types, the docstring is the tool description, and `run()` completes the loop: model picks the call, Needle executes your function, feeds the result back, and returns the final response with the executed tool results attached as `results`.
@@ -119,13 +126,13 @@ Key options: `--epochs` (default 3), `--lora-rank` (16), `--lora-alpha` (32), `-
 Training is plain JAX and runs on any accelerator jax supports. On an NVIDIA machine install the CUDA build and the same command trains on the GPU:
 
 ```sh
-pip install "cactus-needle[gpu]"
+pip install "cactus-needle[train,gpu]"
 ```
 
 On Apple Silicon the `metal` extra trains on the GPU:
 
 ```sh
-pip install "cactus-needle[metal]"
+pip install "cactus-needle[train,metal]"
 ```
 
 **3. Build a tuned `.cact`.** Merge the adapter into the base and quantize. The base auto-downloads if absent.

--- a/doc/finetuning.md
+++ b/doc/finetuning.md
@@ -4,6 +4,12 @@ Needle finetunes with LoRA adapters on the frozen base model: rank 16 on the fiv
 
 ## Data format
 
+Install the training dependencies before running the commands in this guide:
+
+```sh
+pip install "cactus-needle[train]"
+```
+
 One JSON object per line. `query` and `tools` describe the turn, `answers` lists the exact calls the model should emit, `reasoning` is one short line deriving each argument from its source span in the query. `reasoning` is optional but include it: the model produces the derivation before the call, and examples that show where each value comes from teach grounding, not just tool selection.
 
 ```json
@@ -46,13 +52,13 @@ The playground button labelled Finetune on these tools runs the same pipeline fr
 Training is plain JAX, so it runs on any accelerator jax supports. On an NVIDIA machine install the CUDA build and the same command trains on the GPU, nothing else changes:
 
 ```sh
-pip install "cactus-needle[gpu]"
+pip install "cactus-needle[train,gpu]"
 ```
 
 Apple GPUs train through the jax metal plugin, which does not work past jax 0.4.38, so the `metal` extra pins an older stack:
 
 ```sh
-pip install "cactus-needle[metal]"
+pip install "cactus-needle[train,metal]"
 ```
 
 Needle detects the Metal backend and adapts automatically: manual attention, no rematerialisation, unrolled layer stack, and the `ENABLE_PJRT_COMPATIBILITY` variable the plugin requires is set for you. Measured on an M5 Max: 0.71 seconds per step against 2.90 on CPU at the same shape, about 4 times faster, with a one time compile of about 23 seconds. Training runs in float32 on every backend.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,17 +7,23 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 dependencies = [
     "huggingface_hub",
-    "numpy",
-    "jax",
-    "jaxlib",
-    "flax>=0.10.2",
-    "optax",
-    "sentencepiece",
 ]
 
 [project.optional-dependencies]
+train = [
+  "numpy",
+  "jax",
+  "jaxlib",
+  "flax>=0.10.2",
+  "optax",
+  "sentencepiece"
+]
 gpu = ["jax[cuda12]"]
-metal = ["jax==0.4.38", "jaxlib==0.4.38", "jax-metal", "flax==0.10.2", "optax==0.2.4"]
+metal = [
+    "jax==0.4.38",
+    "jaxlib==0.4.38",
+    "jax-metal"
+]
 test = ["pytest", "pydantic"]
 
 [project.scripts]

--- a/requirements-train.txt
+++ b/requirements-train.txt
@@ -1,0 +1,9 @@
+-r requirements.txt
+
+# Training and checkpoint export dependencies
+numpy
+jax
+jaxlib
+flax>=0.10.2
+optax
+sentencepiece

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,2 @@
+# Runtime dependencies
 huggingface_hub
-numpy
-jax
-jaxlib
-flax
-optax
-sentencepiece

--- a/setup
+++ b/setup
@@ -20,11 +20,11 @@ fi
 source "$VENV_DIR/bin/activate"
 
 pip install --upgrade pip -q
-pip install -e . -q
+pip install -e ".[train]" -q
 
 if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
-    echo "NVIDIA GPU detected; installing jax[cuda12]..."
-    pip install -U "jax[cuda12]" -q
+    echo "NVIDIA GPU detected; installing gpu extras..."
+    pip install -e ".[gpu]" -q
 fi
 
 needle --help

--- a/setup.bat
+++ b/setup.bat
@@ -19,6 +19,6 @@ if not exist "%VENV_DIR%\Scripts\python.exe" %PYTHON_CMD% -m venv "%VENV_DIR%"
 call "%VENV_DIR%\Scripts\activate.bat"
 
 python -m pip install --upgrade pip -q
-python -m pip install -e . -q
+python -m pip install -e ".[train]" -q
 
 needle --help

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+
+
+def test_training_dependencies_are_not_required_for_runtime() -> None:
+    root = Path(__file__).parents[1]
+    project = tomllib.loads((root / "pyproject.toml").read_text())
+    runtime = set(project["project"]["dependencies"])
+    training = set(project["project"]["optional-dependencies"]["train"])
+    extras = project["project"]["optional-dependencies"]
+
+    assert runtime.isdisjoint(training)
+    assert extras["gpu"]
+    assert extras["metal"]
+    assert not set(extras["gpu"]).intersection(training)
+    assert not set(extras["metal"]).intersection(training)
+
+    requirements = {
+        line.strip()
+        for line in (root / "requirements.txt").read_text().splitlines()
+        if line.strip() and not line.startswith("#")
+    }
+    train_requirements = {
+        line.strip()
+        for line in (root / "requirements-train.txt").read_text().splitlines()
+        if line.strip() and not line.startswith("#") and not line.startswith("-r ")
+    }
+    assert requirements == runtime
+    assert train_requirements == training


### PR DESCRIPTION
Separate training dependencies from the runtime package

Prepare Needle for runtime-only deployments, such as serving tool-calling requests, without requiring the full training and checkpoint-export stack.

Move training dependencies out of the base installation and expose them through a dedicated `train` extra. Preserve the GPU and Metal extras for accelerated configurations, while keeping the default runtime dependency set minimal.

Changes:
- Add the `train` optional dependency group.
- Add `requirements-train.txt` for requirements-file users.
- Update setup scripts, CI, and documentation to install or explain the training extra where needed.
- Add packaging tests verifying that training dependencies are excluded from the runtime installation and included in the training setup.