### PR TITLE
feat: add uv-compatible setup script

### DIFF
--- a/setup
+++ b/setup
@@ -16,15 +16,26 @@ if [ -z "$PYTHON" ]; then
     exit 1
 fi
 
-[ -d "$VENV_DIR" ] || "$PYTHON" -m venv "$VENV_DIR"
+# Use uv when available (10-100x faster), fall back to pip.
+UV_INSTALL="pip install"
+UV_VENV="$PYTHON -m venv"
+if command -v uv >/dev/null 2>&1; then
+    echo "  uv detected — using uv for package management"
+    UV_INSTALL="uv pip install"
+    UV_VENV="uv venv"
+fi
+
+[ -d "$VENV_DIR" ] || $UV_VENV "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
 
-pip install --upgrade pip -q
-pip install -e . -q
+if [ "$UV_INSTALL" = "pip install" ]; then
+    pip install --upgrade pip -q
+fi
+$UV_INSTALL -e . -q
 
 if command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi >/dev/null 2>&1; then
     echo "NVIDIA GPU detected; installing jax[cuda12]..."
-    pip install -U "jax[cuda12]" -q
+    $UV_INSTALL -U "jax[cuda12]" -q
 fi
 
 needle --help


### PR DESCRIPTION
## Summary

Updates the `setup` bash script to detect and prefer `uv` (the modern, 10-100x faster Python package manager) when available, falling back to pip when uv is not installed.

## Changes

- **`setup`**: Detect `uv` in PATH and use `uv venv` / `uv pip install` instead of `python -m venv` / `pip install` when uv is available
  - Only upgrades pip on the pip fallback path (uv does not need pip upgrades)
  - GPU detection (`nvidia-smi`) works with both paths

## Related

Closes #35
