### PR TITLE
docs: document [train] install extra and telemetry opt-out in llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -7,10 +7,11 @@ This file is written for AI coding assistants. It is enough to write correct Nee
 ## Install
 
 ```sh
-pip install cactus-needle
+pip install cactus-needle                # runtime (inference only)
+pip install "cactus-needle[train]"       # adds JAX + training deps for finetune/build
 ```
 
-`import needle` is lightweight (no JAX). JAX is imported lazily and only by fine-tuning/export/build. The engine binary auto-downloads from Hugging Face on first `Needle(...)` use.
+`import needle` is lightweight (no JAX). JAX is imported lazily and only by fine-tuning/export/build, and the training dependencies live behind the `[train]` extra - a runtime-only install cannot run `needle finetune`/`build`. For GPU training use `[train,gpu]` (CUDA) or `[train,metal]` (Apple Silicon). The engine binary auto-downloads from Hugging Face on first `Needle(...)` use.
 
 ## Core API
 
@@ -160,6 +161,7 @@ LoRA on the frozen base, merged at export. Data is JSONL, one example per line; 
 ```
 
 ```sh
+pip install "cactus-needle[train]"                                                 # training deps (JAX, flax, optax)
 export OPENROUTER_API_KEY=sk-or-...
 needle generate-data --tools my_tools.json --num-samples 500 --output data.jsonl   # optional
 needle finetune data.jsonl --epochs 3 --generate 300                                # LoRA; auto-downloads base
@@ -211,4 +213,8 @@ Adapt by swapping the Literal values for your own and keeping the shapes: closed
 - `import needle` does not import JAX; only `needle finetune`/`build` do.
 - `weights=` expects a `.cact` (from `needle build`), not a `.pkl` checkpoint.
 - The engine cannot unload weights: once a tuned `.cact` is bound, constructing or calling a base-model agent raises instead of silently answering with those weights. Construct agents that want the base model before any tuned one, or run them in separate processes.
+
+## Telemetry
+
+Anonymous usage counts only (function name, package version, OS, random install id - never prompts, outputs, or data). Opt out with `NEEDLE_TELEMETRY=0` or `DO_NOT_TRACK=1`; `CI` environments are excluded automatically.
 ```


### PR DESCRIPTION
## Summary

`llms.txt` is missing two facts that recent changes (#96, #97) added to the README and `doc/finetuning.md`:

1. **The `[train]` install extra** (#97, ee221ce): training dependencies (JAX, flax, optax, sentencepiece) were split out of the runtime package into `pyproject.toml [project.optional-dependencies]`. The README (`pip install "cactus-needle[train]"`, plus `[train,gpu]` / `[train,metal]`) and `doc/finetuning.md` were updated, but `llms.txt`'s Install section still shows only `pip install cactus-needle` and never mentions that a runtime-only install cannot run `needle finetune`/`build` — even though the Fine-tuning section documents those commands and llms.txt itself notes "`import needle` does not import JAX; only `needle finetune`/`build` do".

2. **Telemetry opt-out** (#96, b1554b4): the package now collects anonymous usage telemetry (function name, package version, OS, random install id — never prompts, outputs, or data) with opt-out via `NEEDLE_TELEMETRY=0` / `DO_NOT_TRACK=1`, disclosed in a README Telemetry section. `llms.txt` had zero mention of telemetry or how to disable it, while it already documents sibling environment knobs like `NEEDLE_HF_REPO`, `NEEDLE_LIB_PATH`, and `HF_HUB_OFFLINE`.

## Changes

- Install section: show both install modes, note that training deps live behind `[train]` (with `[train,gpu]`/`[train,metal]` for GPU training), and that a runtime-only install cannot run `needle finetune`/`build`.
- Fine-tuning section: add the `[train]` install as the first step of the CLI pipeline block.
- New short Telemetry section at the end: what is collected (per `needle/_telemetry.py`), opt-out env vars, and that `CI` environments are excluded automatically.

## Verification

- `pyproject.toml` at ee221ce: `train = ["numpy", "jax", "jaxlib", "flax>=0.10.2", "optax", "sentencepiece"]`, `gpu = ["jax[cuda12]"]`, `metal = [...]` — extras syntax matches README/finetuning.md.
- `needle/_telemetry.py`: `_enabled()` returns False for `NEEDLE_TELEMETRY == "0"`, any `DO_NOT_TRACK` value, and `CI`; collected fields are event name, versions, OS/arch, anonymous install id — matches the wording used above.
- README:37 and README:154-156 already document both facts; this PR brings `llms.txt` in line with them.
