### PR TITLE
fix: preserve constraints on optional annotated fields

### DIFF
--- a/needle/agent/tools.py
+++ b/needle/agent/tools.py
@@ -89,10 +89,15 @@ def _json_type(annotation):
 def _field_of(annotation, default):
     if isinstance(default, Field):
         return default
-    if typing.get_origin(annotation) is typing.Annotated:
+    origin = typing.get_origin(annotation)
+    if origin is typing.Annotated:
         for meta in typing.get_args(annotation)[1:]:
             if isinstance(meta, Field):
                 return meta
+    if origin in _UNION_ORIGINS:
+        rest = [a for a in typing.get_args(annotation) if a is not type(None)]
+        if len(rest) == 1:
+            return _field_of(rest[0], _MISSING)
     return None
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -59,6 +59,26 @@ def test_optional_annotation_not_required():
     assert schema["parameters"]["required"] == ["a"]
 
 
+def test_optional_annotated_field_constraints():
+    def f(
+        value: typing.Optional[typing.Annotated[
+            str, Field(pattern="^[a-z]+$", min_length=2, format="email")]] = None,
+        count: typing.Annotated[typing.Optional[int], Field(ge=0)] = None,
+    ):
+        pass
+
+    schema = build_schema(f)
+    properties = schema["parameters"]["properties"]
+    assert properties["value"] == {
+        "type": "string",
+        "pattern": "^[a-z]+$",
+        "minLength": 2,
+        "format": "email",
+    }
+    assert properties["count"] == {"type": "integer", "minimum": 0}
+    assert not {"value", "count"} & set(schema["parameters"].get("required", []))
+
+
 @pep604
 def test_pep604_none_union_not_required():
     def f(a: str, b: str | None = None, c: int | None = None, d: str | int | None = None):


### PR DESCRIPTION
## Summary

- Fixes: Built-in optional tool fields such as contact phone and email, expense merchant, event location, note title, and light brightness omit their declared pattern, format, length, or numeric bounds from the generated schema. As a result, constrained decoding can accept values that the environment declarations and documentation say should be rejected.
- Root cause: `_field_of` only inspects a top-level `Annotated` type. When `Annotated[T, Field(...)]` is wrapped by `Optional`, the helper sees the nullable union and never reaches the `Field` metadata, even though type and requiredness handling already unwrap the same nullable union.

## Regression evidence

- Before: `NEEDLE_TELEMETRY=0 .venv/bin/python -m pytest -q tests/test_tools.py::test_optional_annotated_field_constraints` exited `1`

- After: `NEEDLE_TELEMETRY=0 .venv/bin/python -m pytest -q tests/test_tools.py::test_optional_annotated_field_constraints` exited `0`

## Verification

- `NEEDLE_TELEMETRY=0 .venv/bin/python -m pytest -q tests/test_tools.py tests/test_environments.py`
- `NEEDLE_TELEMETRY=0 .venv/bin/python -m pytest -q -m "not slow"`
- `uv build`
- `git diff --cached --check`

## Scope

- 2 files changed, +26 / -1 lines
