### PR TITLE
serve playground downloads from a private temp dir

### DIFF
--- a/needle/playground/server.py
+++ b/needle/playground/server.py
@@ -11,7 +11,7 @@ _STATIC = {"/": "index.html", "/index.html": "index.html",
 _CTYPE = {".html": "text/html; charset=utf-8",
           ".js": "application/javascript; charset=utf-8",
           ".css": "text/css; charset=utf-8"}
-_DOWNLOADS = Path(tempfile.gettempdir())
+_DOWNLOADS = Path(tempfile.mkdtemp(prefix="needle-playground-"))
 
 
 class Engine:


### PR DESCRIPTION
`_DOWNLOADS` pointed at the system temp directory , so `GET /download/<name>` handed back any file in there and `POST /load-model` overwrote any file in there , repro in #101

one line , `tempfile.mkdtemp(prefix="needle-playground-")` gives each run its own `0700` directory , the generated dataset , the lora , the built `.cact` and the uploaded `.cact` all already go through `_DOWNLOADS` , so nothing else moves

verified both ways on `ee221ce` , a `600` file planted in the temp directory is served on `main` and 404s with this patch , and the write lands inside the private directory instead of clobbering , the playground's own upload then download round trip still works

full suite passes with the training extras installed , 79 passed on `main` and 79 passed with this patch , jax 0.11.1 , flax 0.12.9 , python 3.12

what this does not do , the directory is not removed on exit , same as before , the tuned `.cact` was already being left in temp for the user to collect
