### PR TITLE
fix(release): tag the versioned distribution source

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,16 @@ jobs:
       - id: version
         run: |
           last=$(git tag --list 'v*' --sort=-v:refname | head -1)
-          if [ -n "$last" ] && [ "$(git rev-parse "$last^{commit}")" = "$(git rev-parse HEAD)" ]; then
+          # New release tags include a metadata-only child commit. Its parent
+          # is the main commit that was tested and published.
+          source=""
+          if [ -n "$last" ]; then
+            source=$(git rev-parse "$last^{commit}")
+            if [ "$source" != "$(git rev-parse HEAD)" ] && [ "$(git log -1 --format=%s "$last")" = "chore: release ${last#v}" ]; then
+              source=$(git rev-parse "$last^")
+            fi
+          fi
+          if [ "$source" = "$(git rev-parse HEAD)" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -84,5 +93,11 @@ jobs:
           skip-existing: true
       - if: steps.version.outputs.skip != 'true'
         run: |
+          # Preserve the exact versioned source used for the distribution.
+          # Keep the release-only commit on the tag, without writing to main.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml needle/__init__.py
+          git commit -m "chore: release ${{ steps.version.outputs.next }}"
           git tag "v${{ steps.version.outputs.next }}"
           git push origin "v${{ steps.version.outputs.next }}"

--- a/tests/test_release.py
+++ b/tests/test_release.py
@@ -1,0 +1,70 @@
+"""Exercise the release workflow's Git operations against a local repository."""
+from pathlib import Path
+import subprocess
+import textwrap
+
+import pytest
+
+
+WORKFLOW = Path(__file__).parents[1] / ".github/workflows/release.yaml"
+
+
+def git(repo, *args):
+    return subprocess.check_output(["git", "-C", str(repo), *args], text=True).strip()
+
+
+def run_block(repo, text, **env):
+    import os
+    subprocess.run(["bash", "-eu", "-c", textwrap.dedent(text)], cwd=repo,
+                   env={**os.environ, **env}, check=True)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    git(tmp_path, "init", "-b", "main")
+    git(tmp_path, "config", "user.name", "Release test")
+    git(tmp_path, "config", "user.email", "release@example.invalid")
+    (tmp_path / "needle").mkdir()
+    (tmp_path / "pyproject.toml").write_text('version = "2.0.8"\n')
+    (tmp_path / "needle/__init__.py").write_text('__version__ = "2.0.8"\n')
+    git(tmp_path, "add", ".")
+    git(tmp_path, "commit", "-m", "Initial source")
+    return tmp_path
+
+
+def version_output(repo):
+    workflow = WORKFLOW.read_text()
+    block = workflow.split("      - id: version\n        run: |\n", 1)[1]
+    block = block.split("      - if:", 1)[0]
+    output = repo / "output"
+    output.write_text("")
+    run_block(repo, block, GITHUB_OUTPUT=str(output))
+    return output.read_text().strip()
+
+
+def test_existing_release_tag_skips_unchanged_source(repo):
+    git(repo, "tag", "v2.0.11")
+    assert version_output(repo) == "skip=true"
+
+
+def test_release_tag_contains_versioned_source_and_skips_unchanged_main(repo):
+    original = git(repo, "rev-parse", "HEAD")
+    (repo / "pyproject.toml").write_text('version = "2.0.12"\n')
+    (repo / "needle/__init__.py").write_text('__version__ = "2.0.12"\n')
+    workflow = WORKFLOW.read_text()
+    block = workflow.rsplit("        run: |\n", 1)[1]
+    # The test uses a local tag and never pushes to a remote.
+    block = block.split("          git push", 1)[0]
+    block = block.replace("${{ steps.version.outputs.next }}", "2.0.12")
+    run_block(repo, block)
+    assert git(repo, "show", "v2.0.12:pyproject.toml") == 'version = "2.0.12"'
+    assert git(repo, "show", "v2.0.12:needle/__init__.py") == '__version__ = "2.0.12"'
+    assert git(repo, "rev-parse", "v2.0.12^") == original
+    assert version_output(repo) == "skip=true"
+    git(repo, "checkout", "--detach", original)
+    assert version_output(repo) == "skip=true"
+
+    (repo / "feature.py").write_text("feature = True\n")
+    git(repo, "add", "feature.py")
+    git(repo, "commit", "-m", "Add feature")
+    assert version_output(repo) == "next=2.0.13"


### PR DESCRIPTION
## Summary

Release tags currently point at the original main commit, while the workflow builds distributions from uncommitted version changes. This makes a source install from the tag report an older version than the published distribution.

Commit the two version metadata files before tagging, keeping that release-only commit on the tag without pushing to main. The daily release check recognizes the tagged commit's source parent so an unchanged main branch still skips publication. Existing tags remain supported.

Fixes #104. This corrects future release tags; existing tags are not rewritten.

## Validation

- `python -m pytest tests/test_release.py -q`: 2 passed. Runs the workflow shell blocks in temporary Git repositories to verify tagged metadata, old-style tags, reruns on both the release tag and unchanged main, and the next release after a new source commit. The metadata regression fails against the original workflow.
- `python -m pytest -q -m "not slow"`: 70 passed, 6 skipped, 5 deselected.
- `python -m build`: wheel and source distribution built successfully.

The workflow was not run with publishing credentials; tests do not publish packages or push release tags.
