### PR TITLE
fix(tests): look for the engine where the runtime caches it

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,15 +4,34 @@ import pickle
 import pytest
 
 
-def _engine_available():
+def _engine_available(generation=2):
+    """Whether ``needle._library_path`` would find an engine without downloading.
+
+    Every location this looks in has to be one that function looks in, or the
+    gate skips tests an installed engine could have run.
+    """
     try:
         import needle
         from needle.agent import fetch
+
+        override = os.environ.get(f"NEEDLE{generation}_LIB_PATH")
+        if generation == 2 and not override:
+            override = os.environ.get("NEEDLE_LIB_PATH")
+        if override:
+            return os.path.exists(override)
+
         here = os.path.dirname(needle.__file__)
         name = fetch._lib_name()
-        cache = os.path.join(os.path.expanduser("~"), ".cache",
-                             "cactus-needle", fetch.ENGINE_VERSION, name)
-        return os.path.exists(os.path.join(here, name)) or os.path.exists(cache)
+        stem, suffix = os.path.splitext(name)
+        local_names = [f"{stem}{generation}{suffix}"]
+        if generation == 2:
+            local_names.append(name)
+        if any(os.path.exists(os.path.join(here, local)) for local in local_names):
+            return True
+
+        cache = os.path.join(os.path.expanduser("~"), ".cache", "cactus-needle",
+                             f"v{generation}", fetch.engine_version(generation), name)
+        return os.path.exists(cache)
     except Exception:
         return False
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -62,3 +62,45 @@ def test_fetch_library_creates_destination(tmp_path, monkeypatch):
 
     assert (tmp_path / "new" / "libneedle.so").read_bytes() == b"engine"
     assert out == str(tmp_path / "new" / "libneedle.so")
+
+
+def test_engine_gate_finds_the_cache_the_runtime_loads_from(tmp_path, monkeypatch):
+    import needle
+    from needle.agent import fetch
+    from conftest import _engine_available
+
+    package = tmp_path / "pkg"
+    package.mkdir()
+    monkeypatch.setattr(needle, "__file__", str(package / "__init__.py"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    monkeypatch.delenv("NEEDLE_LIB_PATH", raising=False)
+    monkeypatch.delenv("NEEDLE2_LIB_PATH", raising=False)
+
+    assert not _engine_available()
+
+    cache = tmp_path / ".cache" / "cactus-needle" / "v2" / fetch.engine_version(2)
+    cache.mkdir(parents=True)
+    (cache / fetch._lib_name()).write_bytes(b"")
+
+    assert _engine_available()
+
+
+def test_engine_gate_honours_the_library_override(tmp_path, monkeypatch):
+    import needle
+    from needle.agent import fetch
+    from conftest import _engine_available
+
+    package = tmp_path / "pkg"
+    package.mkdir()
+    monkeypatch.setattr(needle, "__file__", str(package / "__init__.py"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    engine = tmp_path / fetch._lib_name()
+    engine.write_bytes(b"")
+    monkeypatch.setenv("NEEDLE_LIB_PATH", str(engine))
+    assert _engine_available()
+
+    monkeypatch.setenv("NEEDLE_LIB_PATH", str(tmp_path / "gone"))
+    assert not _engine_available()


### PR DESCRIPTION
## Problem

Every `requires_engine` test has been skipped since `cd2f976`, on machines that have the engine.

That commit moved the engine cache under a generation directory. `needle._library_path` now reads:

```python
cache = os.path.join(os.path.expanduser("~"), ".cache", "cactus-needle",
                     f"v{generation}", version)
```

and `needle fetch` writes there, printing `~/.cache/cactus-needle/v2/2.0.4/`. `tests/conftest.py`
was not part of that commit and still looks in the pre-split location:

```python
cache = os.path.join(os.path.expanduser("~"), ".cache",
                     "cactus-needle", fetch.ENGINE_VERSION, name)
```

The `v2` segment is missing, so the gate never finds a fetched engine and the six tests behind it
never run. It also misses the other two ways `_library_path` finds an engine that the same commit
introduced or kept: the `NEEDLE2_LIB_PATH` / `NEEDLE_LIB_PATH` override, and the generation-suffixed
in-package name (`libneedle2.so`).

The skip is silent, so nothing has been failing. The tests simply stopped covering anything.

## Fix

`_engine_available` now mirrors `_library_path`'s lookup order — override, in-package names,
generation-scoped cache — and stops short of the download that function ends with.

## Tests

Two in `tests/test_fetch.py`, both failing before this change:

- `test_engine_gate_finds_the_cache_the_runtime_loads_from` — with `HOME` pointed at a temp tree and
  the package directory empty, the gate is false, then true once an engine file exists at the path
  `_library_path` uses.
- `test_engine_gate_honours_the_library_override` — `NEEDLE_LIB_PATH` at a real file opens the gate;
  pointed at a missing one it does not.

## How I tested

Windows 11, Python 3.12.10, `pip install -e ".[test,train]"`, engine fetched with `needle fetch`
into `C:\Users\...\.cache\cactus-needle\v2\2.0.4\libneedle.dll`.

The six gated tests, before and after:

```
before   25 passed, 6 skipped   (all six "needle C++ engine not installed")
after    31 passed
```

Whole suite, `pytest -q -m "not slow"`:

```
before   64 passed, 9 skipped
after    72 passed, 3 skipped
```

The six that stop skipping are the engine tests; the two extra passes are the tests above. The three
that still skip are the worker integration tests, which want a C compiler. No test changes from
passing to failing.

Both runs exclude `test_lora.py`, `test_render.py`, `test_run.py`, `test_build.py` and
`test_finetune.py`, which need `flax`. That will not install on this machine: `orbax-checkpoint`
ships paths past the Windows `MAX_PATH` limit and pip fails with `WinError 206`. Nothing here
touches that path, and CI runs it on Ubuntu.

Worth noting separately: the engine tests pass on Windows once they actually run, so the gate was
hiding working coverage rather than broken code.
