### PR TITLE
fix: carry the agent's system facts into agent.extract

### DIFF
--- a/needle/__init__.py
+++ b/needle/__init__.py
@@ -205,8 +205,9 @@ class Needle:
 
     def extract(self, text: str, schema: type | dict, max_new_tokens: int = 256,
                 strict: bool = True) -> object:
-        return extract(text, schema, max_new_tokens=max_new_tokens,
-                       weights=self._weights, strict=strict)
+        return extract(text, schema, system=self._system.decode("utf-8") or None,
+                       max_new_tokens=max_new_tokens, weights=self._weights,
+                       strict=strict)
 
     def reset(self):
         self._bind()

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -202,3 +202,49 @@ def test_extraction_rejects_fabricated_temporal_year():
     assert needle._source_years("due September 5") == set()
     assert needle._source_years("due 5th September 42") == {42}
     assert needle._source_years("Invoice 42 is due tomorrow at 5") == set()
+
+
+def test_agent_extract_carries_its_own_system_facts(engine, monkeypatch):
+    import needle
+
+    seen = {}
+
+    def spy(text, schema, system=None, max_new_tokens=256, weights=None, strict=True):
+        seen.update(text=text, system=system, weights=weights, strict=strict)
+        return None
+
+    monkeypatch.setattr(needle, "extract", spy)
+    facts = "date: 2026-07-21 Tue 14:30; locale: en-US"
+    agent = needle.Needle(tools="[]", system=facts)
+
+    assert agent.extract("dinner tomorrow at 7", {"type": "object"}) is None
+    assert seen["system"] == facts
+    assert seen["text"] == "dinner tomorrow at 7"
+
+
+def test_agent_extract_without_system_facts_sends_none(engine, monkeypatch):
+    import needle
+
+    seen = {}
+    monkeypatch.setattr(
+        needle, "extract",
+        lambda text, schema, system=None, **kwargs: seen.update(system=system))
+    needle.Needle(tools="[]").extract("anything", {"type": "object"})
+
+    assert seen["system"] is None
+
+
+def test_agent_extract_still_carries_weights_and_strict(engine, tuned, monkeypatch):
+    import needle
+
+    seen = {}
+    monkeypatch.setattr(
+        needle, "extract",
+        lambda text, schema, system=None, max_new_tokens=256, weights=None, strict=True:
+            seen.update(system=system, weights=weights, strict=strict))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        agent = needle.Needle(tools="[]", weights=tuned, system="device: phone")
+    agent.extract("anything", {"type": "object"}, strict=False)
+
+    assert seen == {"system": "device: phone", "weights": tuned, "strict": False}


### PR DESCRIPTION
## Problem

`agent.extract(...)` drops the system facts the agent was built with.

```python
def extract(self, text, schema, max_new_tokens=256, strict=True):
    return extract(text, schema, max_new_tokens=max_new_tokens,
                   weights=self._weights, strict=strict)
```

`weights` and `strict` are forwarded; `self._system` is not, so the module-level `extract` builds its
one-shot agent with `system=None`.

That matters because system facts are what license relative language. From the docs:

> Relative language ("tomorrow at 7") resolves only when a `date:` fact licenses it.

So an agent created the documented way:

```python
agent = needle.Needle(tools=tools, system="date: 2026-07-21 Tue 14:30; locale: en-US")
agent.extract("dinner tomorrow at 7", Reservation)
```

extracts without the date it was given, while the module-level call one line away keeps it:

```python
needle.extract("dinner tomorrow at 7", Reservation, system="date: 2026-07-21 Tue 14:30")
```

With `strict=True`, the default, the loss compounds: `_temporal_grounding` checks extracted dates
against years found in the source, and an unlicensed relative date has nothing to ground against.

Observed on `main` by watching what the inner agent is constructed with:

```
system the agent was built with : 'date: 2026-07-21 Tue 14:30; locale: en-US'
system reaching extract's Needle: None
```

## Fix

Forward `self._system`, decoded, with an empty string sent as `None` so an agent built without facts
behaves exactly as before.

## Tests

Three in `tests/test_weights.py`, on the existing `engine` fixture:

- `test_agent_extract_carries_its_own_system_facts` — the facts reach `extract`. Fails before.
- `test_agent_extract_without_system_facts_sends_none` — no facts still means `None`, not `""`.
- `test_agent_extract_still_carries_weights_and_strict` — the two arguments that already worked keep
  working, alongside the facts. Fails before.

## How I tested

Windows 11, Python 3.12.10. `pytest -q -m "not slow"` gives 67 passed, 9 skipped, up from 64 by the
three new tests; nothing else moves. The 9 skips are the six engine tests and the three worker tests
that want a C compiler.

`test_lora.py`, `test_render.py`, `test_run.py`, `test_build.py` and `test_finetune.py` are excluded:
they need `flax`, whose `orbax-checkpoint` dependency will not install on Windows because its paths
exceed `MAX_PATH`. Nothing here touches them, and CI runs them on Ubuntu.

One thing worth a maintainer's opinion: `Needle.extract` is public but is not in `llms.txt` or
`doc/apis.md`, which document only the module-level `extract`. Happy to add a line for it in either
file if you want it documented rather than quietly available.
